### PR TITLE
fix(drush) update to new drush 9 user-add-role

### DIFF
--- a/src/Drupal/UserRegistry/DrushTestUserManager.php
+++ b/src/Drupal/UserRegistry/DrushTestUserManager.php
@@ -125,7 +125,7 @@ class DrushTestUserManager implements TestUserManagerInterface
                 if ($role != "Authenticated") {
                     $this->runDrush(
                         sprintf(
-                            "user-add-role %s --name=%s",
+                            "user-add-role %s %s",
                             escapeshellarg($role),
                             escapeshellarg($user->name)
                         )


### PR DESCRIPTION
```
[cibuild@cmh web]$ drush help user-add-role
Add a role to the specified user accounts.

Examples:
  drush user:add-role "power user" user3 Add the "power user" role to user3

Arguments:
  role  The name of the role to add.
  names A comma delimited list of user names.
```